### PR TITLE
:sparkles: allow-* で指定した文字種のみ許可するようにした

### DIFF
--- a/src/mi-password-input.ts
+++ b/src/mi-password-input.ts
@@ -14,6 +14,12 @@ export class MIPasswordInput extends LitElement {
   @property({ type: String })
   required = '';
 
+  @property({ type: Boolean, attribute: 'allow-lower' })
+  allowLower = false;
+
+  @property({ type: Boolean, attribute: 'allow-upper' })
+  allowUpper = false;
+
   parseRequired(s: string): boolean {
     if (s === 'true') {
       return true;
@@ -40,6 +46,15 @@ export class MIPasswordInput extends LitElement {
     const o: Config = {
       minlength: minlength || undefined,
       maxlength: maxlength || undefined,
+      allow: {
+        lower: this.allowLower,
+        upper: this.allowUpper,
+        // NOTE:
+        // 数字のみ補完されるようにするためには allowed: digit ルールを明示的に追加する必要がある
+        // 現在の設計では allowDigit を false にするメリットがないため attribute として宣言はしないが
+        // 変数として定義はしておき true を強制する
+        digit: true,
+      },
     };
     return genPasswordRules(o);
   }

--- a/src/utils/gen_password_rules.test.ts
+++ b/src/utils/gen_password_rules.test.ts
@@ -5,6 +5,11 @@ test('single', () => {
   const o: Config = {
     minlength: 6,
     maxlength: undefined,
+    allow: {
+      lower: false,
+      upper: false,
+      digit: false,
+    },
   };
   expect(genPasswordRules(o)).toBe('minlength: 6');
 });
@@ -13,6 +18,26 @@ test('multi', () => {
   const o: Config = {
     minlength: 6,
     maxlength: 12,
+    allow: {
+      lower: false,
+      upper: false,
+      digit: false,
+    },
   };
   expect(genPasswordRules(o)).toBe('minlength: 6;maxlength: 12');
+});
+
+test('config allow char', () => {
+  const o: Config = {
+    minlength: 6,
+    maxlength: 12,
+    allow: {
+      lower: true,
+      upper: true,
+      digit: true,
+    },
+  };
+  expect(genPasswordRules(o)).toBe(
+    'minlength: 6;maxlength: 12;allowed: lower, upper, digit',
+  );
 });

--- a/src/utils/gen_password_rules.ts
+++ b/src/utils/gen_password_rules.ts
@@ -1,27 +1,40 @@
 export type Config = {
   minlength?: number;
   maxlength?: number;
+  allow: {
+    lower: boolean;
+    upper: boolean;
+    // アラビア数字
+    digit: boolean;
+  };
 };
 
-export function genPasswordRules(o: Config) {
-  let list: string[] = [];
+export function genPasswordRules(o: Config): string {
+  let ruleList: string[] = [];
+  let allowedList: string[] = [];
   Object.entries(o).forEach(([k, v]) => {
     if (!k || !v) {
       return;
     }
-    list.push(`${k}: ${v}`);
+    switch (k) {
+      case 'allow':
+        Object.entries(o[k]).forEach(([k2, v2]) => {
+          if (!k2 || !v2) {
+            return;
+          }
+          allowedList.push(`${k2}`);
+        });
+        return;
+      default:
+        ruleList.push(`${k}: ${v}`);
+        return;
+    }
   });
 
-  const r = list.join(';');
+  if (allowedList.length) {
+    ruleList.push(`allowed: ${allowedList.join(', ')}`);
+  }
+
+  const r = ruleList.join(';');
   return r;
 }
-
-// passwordrules="minlength: 6; required: lower; required: upper; required: digit; allowed: [-().&@?'#,/&quot;+];"
-
-// requiredCharacter: {
-//   lower: boolean;
-//   upper: boolean;
-//   digit: boolean;
-//   custom: string;
-// };
-// allowedCharacter: string[];


### PR DESCRIPTION
## やったこと
パスワード input で、パスワードマネージャに補完される文字種を指定できるようにした。
allow-* を明示的に指定しない場合、数字のみ許可される。

## 確認したこと

### allow-* を明示的に指定しない場合数値のみ許可される

![image](https://github.com/user-attachments/assets/8029007d-27f0-4732-8ff0-319fb397619f)

```html
    <mi-password-input
      minlength="4"
      maxlength="6"
      required="true"
    ></mi-password-input>
```

### allow-lower を指定すると小文字アルファベットが許可される

![image](https://github.com/user-attachments/assets/786209a3-b30f-46b8-84a8-1a05b66e17d9)

```html
    <mi-password-input
      minlength="4"
      maxlength="6"
      required="true"
      allow-lower
    ></mi-password-input>
```

### allow-upper を指定すると大文字アルファベットが許可される

![image](https://github.com/user-attachments/assets/78e98e2c-49d2-4b96-947d-4b21fde68318)


```html
    <mi-password-input
      minlength="4"
      maxlength="6"
      required="true"
      allow-lower
      allow-upper
    ></mi-password-input>
```